### PR TITLE
Increase the node size of azure cluster

### DIFF
--- a/script/azure
+++ b/script/azure
@@ -22,7 +22,7 @@ cd litmus
 cd k8s/azure/k8s-installer
 echo "creating  cluster"
 
-ansible-playbook create-k8s-cluster.yml -v --extra-vars "nodes=3"
+ansible-playbook create-k8s-cluster.yml -v --extra-vars "nodes=3 node_size=Standard_D3"
 
 sleep 30
 kubectl get nodes


### PR DESCRIPTION
- Increase the node vm size of AKS from `Standard_D1` to `Standard_D3`
