### PR TITLE
updated gitlab-ci.yml to have image tag as variable

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -13,7 +13,7 @@ stages:
 ## Setup the kubernetes cluster
 
 azure-cluster:
-  image: atulabhi/kops:v8
+  image: atulabhi/kops:$VER
   stage: CLUSTER-SETUP 
   script: 
     - ./script/azure
@@ -24,7 +24,7 @@ azure-cluster:
 ## Setup OpenEBS control plane
 
 openebs-azure-deploy:
-  image: atulabhi/kops:v8
+  image: atulabhi/kops:$VER
   stage: PROVIDER-INFRA-SETUP
   dependencies:
     - azure-cluster
@@ -37,7 +37,7 @@ openebs-azure-deploy:
 ## Define a job template for app deployers
 
 .app_deploy_template:
-  image: atulabhi/kops:v8
+  image: atulabhi/kops:$VER
   stage: STATEFUL-APP-DEPLOY 
   dependencies:
     - openebs-azure-deploy
@@ -159,7 +159,7 @@ volume-data-integrity-{fio-jiva}:
 ## Define job template for chaos jobs 
 
 .chaos_test_template:
-  image: atulabhi/kops:v8
+  image: atulabhi/kops:$VER
   stage: APP-CHAOS-TEST
   when: always 
   artifacts:
@@ -198,7 +198,7 @@ tgt-disconnect-{mongo-cstor}:
 
 cleanup-azure:
   when: always
-  image: atulabhi/kops:v8
+  image: atulabhi/kops:$VER
   dependencies:
     - azure-cluster
   stage: CLUSTER-CLEANUP


### PR DESCRIPTION
The az binary required to  create the cluster has been pushed in the kops image but gitlab runner is not fetching the latest image and instead uses the the  local image which is already there. which doesn't have the az binary. So a new image is pushed to dockerhub with different tag and the gitlab-ci.yml has been updated to fetch the image based on tag variable which is being passed to runner from gitlab as an env.
This pr fixes:- https://github.com/openebs/e2e-azure/issues/17

Signed-off-by: atulabhi atulabhi@gmail.com